### PR TITLE
fix: failed to copy template files on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "inquirer": "^7.3.2",
     "is-utf8": "^0.2.1",
     "license.js": "^3.1.2",
+    "slash": "^3.0.0",
     "uuid": "^8.2.0",
     "yargs-interactive": "^3.0.0"
   },

--- a/src/template.ts
+++ b/src/template.ts
@@ -3,6 +3,7 @@ import globby from 'globby';
 import Handlebars from 'handlebars';
 import isUtf8 from 'is-utf8';
 import path from 'path';
+import slash from 'slash';
 import { v4 as uuidv4 } from 'uuid';
 import { View } from '.';
 
@@ -75,7 +76,7 @@ export interface CopyConfig {
 }
 
 export async function copy(args: CopyConfig) {
-  const templateFiles = await globby(args.templateDir, { dot: true });
+  const templateFiles = await globby(slash(args.templateDir), { dot: true });
   for (const sourcePath of templateFiles) {
     const relativePath = path.relative(args.templateDir, sourcePath);
     const targetPath = format(


### PR DESCRIPTION
I looked into the problem with Create Book not working on Windows (https://github.com/vivliostyle/create-book/issues/3) and found that it was caused by this problem on create-create-app.

```ts
  const templateFiles = await globby(args.templateDir, { dot: true });
```

On Windows, this `globby(…)` returns empty array `[]`, so the templateFiles becomes empty and the template files are not copied to the target directory.

I found this problem occurs when the templateDir contains backslashes (Windows directory separator). So I put `slash(…)` to convert the backslash to slash, and this works fine:

```ts
  const templateFiles = await globby(slash(args.templateDir), { dot: true });
```

This seems a problem of fast-glob used in globby. Perhaps the following fast-glob issue is relevant:
https://github.com/mrmlnc/fast-glob/issues/240

