### PR TITLE
allow to use UNLICENSED as license

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -265,14 +265,18 @@ export async function create(appName: string, options: Options) {
   })
 
   // create LICENSE
-  const license = makeLicenseSync(args.license, {
-    year,
-    project: name,
-    description: args.description,
-    organization: getContact(args.author, args.email),
-  })
-  const licenseText = license.header + license.text + license.warranty
-  fs.writeFileSync(path.resolve(packageDir, 'LICENSE'), licenseText)
+  try {
+    const license = makeLicenseSync(args.license, {
+      year,
+      project: name,
+      description: args.description,
+      organization: getContact(args.author, args.email),
+    })
+    const licenseText = license.header + license.text + license.warranty
+    fs.writeFileSync(path.resolve(packageDir, 'LICENSE'), licenseText)
+  } catch (e) {
+    // do not generate LICENSE
+  }
 
   // install dependencies using yarn / npm
   const useYarn = await IsYarnAvailable()

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -6,62 +6,97 @@ import * as os from 'os'
 const TEST_WORK_DIR = path.join(os.tmpdir(), 'jest_create_create_app_setup')
 const TEST_CURRENT_DIR = process.cwd()
 
-beforeAll(() => {
-  fs.mkdirSync(TEST_WORK_DIR, { recursive: true })
-})
-
-afterAll(() => {
-  fs.rmdirSync(TEST_WORK_DIR, { recursive: true })
-})
-
-beforeEach(() => {
-  // skip
-})
-
-afterEach(() => {
-  // back to current dir
-  process.chdir(TEST_CURRENT_DIR)
-})
-
-test('create', async () => {
-  process.argv = [
-    'create',
-    'create-app',
-    'sample_book',
-    '--description',
-    'desc.',
-    '--author',
-    'Awesome Doe',
-    '--email',
-    'awesome@example.com',
-    '--license',
-    'Apache-2.0',
-  ]
-  process.chdir(TEST_WORK_DIR)
-
-  const opts = await create('foo', {
-    templateRoot: `${TEST_CURRENT_DIR}/templates`,
+describe('create()', () => {
+  beforeEach(() => {
+    fs.mkdirSync(TEST_WORK_DIR, { recursive: true })
   })
 
-  const newReadMe = fs.readFileSync(`${TEST_WORK_DIR}/sample_book/README.md`)
-  expect(newReadMe.toString()).toMatch('# Sample Book')
-  expect(newReadMe.toString()).toMatch('- {{author}} => Awesome Doe')
-  expect(newReadMe.toString()).toMatch('- {{email}} => awesome@example.com')
-  expect(newReadMe.toString()).toMatch(
-    'See https://github.com/uetchy/create-create-app#template for the further details.'
-  )
+  afterEach(() => {
+    fs.rmdirSync(TEST_WORK_DIR, { recursive: true })
+    // back to current dir
+    process.chdir(TEST_CURRENT_DIR)
+  })
 
-  const newPackageJson = fs.readFileSync(
-    `${TEST_WORK_DIR}/sample_book/package.json`
-  )
-  expect(newPackageJson.toString()).toMatch('"name": "sample-book",')
-  expect(newPackageJson.toString()).toMatch('"description": "desc.",')
-  expect(newPackageJson.toString()).toMatch(
-    '"author": "Awesome Doe <awesome@example.com>",'
-  )
-  expect(newPackageJson.toString()).toMatch('"license": "Apache-2.0"')
+  test('create app', async () => {
+    process.argv = [
+      'create',
+      'create-app',
+      'sample_book',
+      '--description',
+      'desc.',
+      '--author',
+      'Awesome Doe',
+      '--email',
+      'awesome@example.com',
+      '--license',
+      'Apache-2.0',
+    ]
+    process.chdir(TEST_WORK_DIR)
 
-  const newSrcCli = fs.readFileSync(`${TEST_WORK_DIR}/sample_book/src/cli.js`)
-  expect(newSrcCli.toString()).toMatch('#!/usr/bin/env node')
-  expect(newSrcCli.toString()).toMatch("create('sample-book', {")
-}, 300000)
+    const opts = await create('foo', {
+      templateRoot: `${TEST_CURRENT_DIR}/templates`,
+    })
+
+    const newReadMe = fs.readFileSync(`${TEST_WORK_DIR}/sample_book/README.md`)
+    expect(newReadMe.toString()).toMatch('# Sample Book')
+    expect(newReadMe.toString()).toMatch('- {{author}} => Awesome Doe')
+    expect(newReadMe.toString()).toMatch('- {{email}} => awesome@example.com')
+    expect(newReadMe.toString()).toMatch(
+      'See https://github.com/uetchy/create-create-app#template for the further details.'
+    )
+
+    const newPackageJson = fs.readFileSync(
+      `${TEST_WORK_DIR}/sample_book/package.json`
+    )
+    expect(newPackageJson.toString()).toMatch('"name": "sample-book",')
+    expect(newPackageJson.toString()).toMatch('"description": "desc.",')
+    expect(newPackageJson.toString()).toMatch(
+      '"author": "Awesome Doe <awesome@example.com>",'
+    )
+    expect(newPackageJson.toString()).toMatch('"license": "Apache-2.0"')
+
+    const newSrcCli = fs.readFileSync(`${TEST_WORK_DIR}/sample_book/src/cli.js`)
+    expect(newSrcCli.toString()).toMatch('#!/usr/bin/env node')
+    expect(newSrcCli.toString()).toMatch("create('sample-book', {")
+  }, 300000)
+
+  test('create unlicensed app', async () => {
+    process.argv = [
+      'create',
+      'create-app',
+      'sample_book',
+      '--description',
+      'desc.',
+      '--author',
+      'Awesome Doe',
+      '--email',
+      'awesome@example.com',
+      '--license',
+      'UNLICENSED',
+    ]
+    process.chdir(TEST_WORK_DIR)
+
+    const opts = await create('foo', {
+      templateRoot: `${TEST_CURRENT_DIR}/templates`,
+      extra: {
+        license: {
+          type: 'list',
+          describe: 'license',
+          choices: availableLicenses().concat(['UNLICENSED']) as (
+            | string
+            | { name: string; value: any }
+          )[],
+          prompt: 'if-no-arg',
+        },
+      },
+    })
+
+    const newPackageJson = fs.readFileSync(
+      `${TEST_WORK_DIR}/sample_book/package.json`
+    )
+    expect(newPackageJson.toString()).toMatch('"license": "UNLICENSED"')
+
+    const existed = fs.existsSync(`${TEST_WORK_DIR}/sample_book/LICENSE`)
+    expect(existed).toBeFalsy()
+  }, 300000)
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { create } from '../src/index'
+import { availableLicenses } from 'license.js'
 import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'


### PR DESCRIPTION
This PR is a draft to fix #22.

It is a bit conservative, "using `extra` arguments in `create()`", and do not add `{"private": true}` in package.json.