### PR TITLE
fix: avoid crashes when .gitconfig exists but user is not set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export class CLIError extends Error {
 async function getGitUser(): Promise<{ name?: string; email?: string }> {
   try {
     const config = await gitconfig.get({ location: 'global' });
-    return config.user;
+    return config.user ?? {};
   } catch (err) {
     return {};
   }


### PR DESCRIPTION
Create Book で起きている次の問題の修正:

- Crashes when .gitconfig exists but user is not set
    https://github.com/vivliostyle/create-book/issues/15

