### PR TITLE
Fix typescript "npm run clean"

### DIFF
--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -5,7 +5,7 @@
   "author": "{{contact}}",
   "scripts": {
     "build": "tsup src/cli.ts --minify",
-    "clean": "shx rm -rf lib",
+    "clean": "shx rm -rf dist",
     "dev": "tsup src/cli.ts --watch",
     "prepublishOnly": "npm run clean && npm run build"
   },
@@ -16,6 +16,7 @@
   ],
   "devDependencies": {
     "@types/node": "^17.0.29",
+    "shx": "^0.3.4",
     "tsup": "^5.12.1",
     "typescript": "^4.6.3"
   },


### PR DESCRIPTION
You couldn't publish with the default generated package because the clean was broken

I've included the shx depedency & fixed the path deleted (dist, not lib)