### PR TITLE
update installNpmPackage type match runtime args

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,10 @@ export interface AfterHookOptions {
   ) => ExecaChildProcess<string>;
 
   /** install npm package. uses package manager specified by --node-pm CLI param (default: auto-detect) */
-  installNpmPackage: (packageName: string, isDev?: boolean) => Promise<void>;
+  installNpmPackage: (
+    packageName: string | string[],
+    isDev?: boolean
+  ) => Promise<void>;
 }
 
 export class CLIError extends Error {


### PR DESCRIPTION
This updates the type exported for `installNpmPackage()` in `AfterHookOptions` to allow the input of a string array, as is allowed in the implementation of the function.