### PR TITLE
support Bun

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export interface Options {
 
   /** Default value for package manager (default: `undefined`)
    *
-   * `npm`, `yarn` and `pnpm` are available. `undefined` to auto detect package manager. */
+   * `npm`, `yarn`, `pnpm` and `bun` are available. `undefined` to auto detect package manager. */
   defaultPackageManager?: PackageManager;
 
   /** Interactively asks users for a description */
@@ -312,7 +312,7 @@ export async function create(appName: string, options: Options) {
     'node-pm': {
       type: 'list',
       describe: 'Package manager to use for installing packages from npm',
-      choices: ['npm', 'yarn', 'pnpm'],
+      choices: ['npm', 'yarn', 'pnpm', 'bun'],
       default: defaultPackageManager, // undefined by default, we'll try to guess pm later
       prompt: promptForPackageManager ? 'if-no-arg' : 'never',
     },

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,7 +1,7 @@
 import { CLIError, printCommand } from '.';
 import { spawnPromise } from './fs';
 
-export type PackageManager = 'npm' | 'yarn' | 'pnpm';
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 
 // License for `whichPm`
 // The MIT License (MIT)
@@ -27,27 +27,23 @@ export async function initPackage(
     pm: PackageManager;
   }
 ) {
-  let command: string;
+  const command: string = pm === 'yarn' ? 'yarnpkg' : pm;
   let args: string[];
 
   switch (pm) {
-    case 'npm': {
-      command = 'npm';
+    case 'npm':
+    case 'pnpm':
+    case 'bun': {
       args = ['init', '-y'];
       process.chdir(rootDir);
       break;
     }
     case 'yarn': {
-      command = 'yarnpkg';
       args = ['init', '-y', '--cwd', rootDir];
       break;
     }
-    case 'pnpm': {
-      command = 'pnpm';
-      args = ['init', '-y'];
-      process.chdir(rootDir);
-      break;
-    }
+    default:
+      throw new CLIError(`Unsupported package manager: ${pm}`);
   }
 
   printCommand(command, ...args);
@@ -60,26 +56,26 @@ export async function initPackage(
 }
 
 export async function installDeps(rootDir: string, pm: PackageManager) {
-  let command: string;
+  const command: string = pm === 'yarn' ? 'yarnpkg' : pm;
   let args: string[];
 
   switch (pm) {
-    case 'npm': {
-      command = 'npm';
+    case 'npm':
+    case 'bun': {
       args = ['install'];
       process.chdir(rootDir);
       break;
     }
     case 'yarn': {
-      command = 'yarnpkg';
       args = ['install', '--cwd', rootDir];
       break;
     }
     case 'pnpm': {
-      command = 'pnpm';
       args = ['install', '--dir', rootDir];
       break;
     }
+    default:
+      throw new CLIError(`Unsupported package manager: ${pm}`);
   }
 
   printCommand(command, ...args);
@@ -102,26 +98,26 @@ export async function addDeps(
     pm: PackageManager;
   }
 ) {
-  let command: string;
+  const command: string = pm === 'yarn' ? 'yarnpkg' : pm;
   let args: string[];
 
   switch (pm) {
     case 'npm': {
-      command = 'npm';
       args = ['install', isDev ? '-D' : '-S', ...deps];
       process.chdir(rootDir);
       break;
     }
-    case 'yarn': {
-      command = 'yarnpkg';
+    case 'yarn':
+    case 'bun': {
       args = ['add', '--cwd', rootDir, ...deps, isDev ? '-D' : ''];
       break;
     }
     case 'pnpm': {
-      command = 'pnpm';
       args = ['add', '--dir', rootDir, ...deps, isDev ? '-D' : ''];
       break;
     }
+    default:
+      throw new CLIError(`Unsupported package manager: ${pm}`);
   }
 
   printCommand(command, ...args);


### PR DESCRIPTION
Thank you for developing such wonderful OSS.

When I ran create-create-app using Bun, the following error occurred.

```
$ bun create create-app hoge                                                       (node:49250) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
? Description description
? Author name Songmu
? Author email y.songmu@gmail.com
? Template default
? License MIT

Creating a new package in /Users/Songmu/temporary/work-20250204-195056/create-hoge.

Initializing a git repository
> git init
Installing the latest version of create-create-app
# TypeError
s is not iterable (cannot read property undefined)

TypeError: s is not iterable (cannot read property undefined)
    at K (/private/tmp/bunx-501-create-create-app@latest/node_modules/create-create-app/lib/cli.js:2:2100)
    at _ (/private/tmp/bunx-501-create-create-app@latest/node_modules/create-create-app/lib/cli.js:5:76)
    at after (/private/tmp/bunx-501-create-create-app@latest/node_modules/create-create-app/lib/cli.js:20:336)
    at le (/private/tmp/bunx-501-create-create-app@latest/node_modules/create-create-app/lib/cli.js:5:351)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

# Environment
- create-create-app: 7.3.0
- System > OS: macOS 15.3
- Binaries > Node: 22.4.0 - ~/.local/share/mise/installs/node/22.4.0/bin/node

If you think this is a bug, please report at https://github.com/uetchy/create-create-app/issues along with the information above.
```

This is because create-create-app does not support Bun as a package manager.

In the pull request, I supported Bun and added error handling within the switch statement to make the error message easier to understand.

It is up to you to decide whether or not we should support Bun.